### PR TITLE
Add useModuleStatus hook

### DIFF
--- a/frontend/TODO.md
+++ b/frontend/TODO.md
@@ -24,8 +24,8 @@
 
 ---
 
-## Milestone 3 — Mark-Complete UI
-- [ ] `useModuleStatus` hook (localStorage)                                 [Codex-OK]
+-## Milestone 3 — Mark-Complete UI
+- [x] `useModuleStatus` hook (localStorage)                                 [Codex-OK]
 - [ ] “✔ Mark complete” button → lock/unlock next module                    [Codex-OK]
 - [ ] **If module doc contains `assetURL`** (Cloudinary) render             [Codex-OK]  
       `Download starter code` link (`<a href … download>`)

--- a/frontend/src/hooks/useModuleStatus.tsx
+++ b/frontend/src/hooks/useModuleStatus.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export interface ModuleStatus {
+  isComplete: boolean;
+  markComplete: () => void;
+  reset: () => void;
+}
+
+export function useModuleStatus(courseId: string, moduleId: string): ModuleStatus {
+  const key = `progress/${courseId}/${moduleId}`;
+  const [isComplete, setIsComplete] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(key) === 'true';
+  });
+
+  const markComplete = () => setIsComplete(true);
+  const reset = () => setIsComplete(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (isComplete) {
+      localStorage.setItem(key, 'true');
+    } else {
+      localStorage.removeItem(key);
+    }
+  }, [isComplete, key]);
+
+  return { isComplete, markComplete, reset };
+}

--- a/frontend/tests/use-module-status.test.tsx
+++ b/frontend/tests/use-module-status.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useModuleStatus } from '../src/hooks/useModuleStatus';
+
+describe('useModuleStatus', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('initializes from localStorage', () => {
+    window.localStorage.setItem('progress/neuro101/neuro101-01', 'true');
+    const { result } = renderHook(() => useModuleStatus('neuro101', 'neuro101-01'));
+    expect(result.current.isComplete).toBe(true);
+  });
+
+  it('marks module as complete and saves to localStorage', () => {
+    const { result } = renderHook(() => useModuleStatus('neuro101', 'neuro101-02'));
+    act(() => result.current.markComplete());
+    expect(window.localStorage.getItem('progress/neuro101/neuro101-02')).toBe('true');
+    expect(result.current.isComplete).toBe(true);
+  });
+
+  it('reset clears localStorage entry', () => {
+    const { result } = renderHook(() => useModuleStatus('neuro101', 'neuro101-03'));
+    act(() => result.current.markComplete());
+    act(() => result.current.reset());
+    expect(window.localStorage.getItem('progress/neuro101/neuro101-03')).toBeNull();
+    expect(result.current.isComplete).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes frontend/TODO#M3-1

## Implementation details
- created `useModuleStatus` hook storing progress in `localStorage`
- added Jest tests for the hook
- marked milestone item as complete

All lint, build and test commands pass.


------
https://chatgpt.com/codex/tasks/task_e_684b0526d724833382b94def4b123876