### PR TITLE
Implement mark-complete unlocking feature

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -3,6 +3,9 @@ module.exports = {
   testEnvironment: 'jsdom',
   testMatch: ['**/tests/**/*.test.ts?(x)'],
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@eslint/eslintrc": "^3",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -3544,6 +3545,20 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@eslint/eslintrc": "^3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/frontend/src/components/MarkCompleteSection.tsx
+++ b/frontend/src/components/MarkCompleteSection.tsx
@@ -1,0 +1,40 @@
+"use client";
+import Link from "next/link";
+import { useModuleStatus } from "@/hooks/useModuleStatus";
+import type { ModuleEntry } from "@/mdxModules";
+
+export default function MarkCompleteSection({
+  courseId,
+  moduleId,
+  next,
+}: {
+  courseId: string;
+  moduleId: string;
+  next?: ModuleEntry;
+}) {
+  const { isComplete, markComplete } = useModuleStatus(courseId, moduleId);
+  const nextUnlocked = isComplete;
+  return (
+    <div>
+      <button
+        className="rounded bg-green-600 px-3 py-1 text-white"
+        disabled={isComplete}
+        onClick={markComplete}
+      >
+        {isComplete ? "Completed" : "✔ Mark complete"}
+      </button>
+      {next && (
+        nextUnlocked ? (
+          <Link
+            href={`/courses/${courseId}/modules/${next.meta.moduleId}`}
+            className="ml-4 text-blue-600 underline"
+          >
+            Next module
+          </Link>
+        ) : (
+          <span className="ml-4 text-gray-500">Next module locked</span>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ModulePage.tsx
+++ b/frontend/src/components/ModulePage.tsx
@@ -1,4 +1,6 @@
 import type { ComponentType } from "react";
+import { getCourseModules, ModuleEntry } from "@/mdxModules";
+import MarkCompleteSection from "./MarkCompleteSection";
 
 export function ModulePagePure({
   courseId,
@@ -9,13 +11,18 @@ export function ModulePagePure({
   moduleId: string;
   Content: ComponentType;
 }) {
+  const modules = getCourseModules(courseId);
+  const idx = modules.findIndex((m) => m.meta.moduleId === moduleId);
+  const next: ModuleEntry | undefined = idx >= 0 ? modules[idx + 1] : undefined;
+
   return (
-    <main className="p-8">
+    <main className="p-8 space-y-4">
       <h1 className="text-2xl font-semibold">Course: {courseId}</h1>
-      <p className="mt-4 text-lg">Module: {moduleId}</p>
+      <p className="text-lg">Module: {moduleId}</p>
       <div className="prose mt-6">
         <Content />
       </div>
+      <MarkCompleteSection courseId={courseId} moduleId={moduleId} next={next} />
     </main>
   );
 }

--- a/frontend/src/mdxModules.ts
+++ b/frontend/src/mdxModules.ts
@@ -1,16 +1,54 @@
 import type { ComponentType } from 'react';
+
 import ModuleNeuro10101 from '../content/neuro101/01-cells-and-membranes.mdx';
 import ModuleNeuro10102 from '../content/neuro101/02-action-potentials.mdx';
 
-interface ModuleEntry {
-  Component: ComponentType;
+export interface ModuleMeta {
+  courseId: string;
+  moduleId: string;
+  title: string;
+  order: number;
+  unlockIf: string;
+  assetURL: string;
 }
 
+export interface ModuleEntry {
+  Component: ComponentType;
+  meta: ModuleMeta;
+}
+
+
 const modules: Record<string, ModuleEntry> = {
-  'neuro101/neuro101-01': { Component: ModuleNeuro10101 },
-  'neuro101/neuro101-02': { Component: ModuleNeuro10102 },
+  'neuro101/neuro101-01': {
+    Component: ModuleNeuro10101,
+    meta: {
+      courseId: 'neuro101',
+      moduleId: 'neuro101-01',
+      title: 'Cells & Membranes',
+      order: 1,
+      unlockIf: '',
+      assetURL: '',
+    },
+  },
+  'neuro101/neuro101-02': {
+    Component: ModuleNeuro10102,
+    meta: {
+      courseId: 'neuro101',
+      moduleId: 'neuro101-02',
+      title: 'Action Potential',
+      order: 2,
+      unlockIf: 'neuro101-01',
+      assetURL: '',
+    },
+  },
 };
 
 export function getMdxModule(courseId: string, moduleId: string): ModuleEntry | undefined {
   return modules[`${courseId}/${moduleId}`];
+}
+
+export function getCourseModules(courseId: string): ModuleEntry[] {
+  return Object.values(modules)
+    .filter((m) => m.meta.courseId === courseId)
+    .sort((a, b) => a.meta.order - b.meta.order);
 }

--- a/frontend/tests/module-page.test.tsx
+++ b/frontend/tests/module-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ModulePagePure } from '../src/components/ModulePage';
 import { getMdxModule } from '../src/mdxModules';
 
@@ -23,6 +24,7 @@ describe('ModulePage', () => {
       />
     );
     expect(screen.getByRole('heading', { name: 'Cells & Membranes' })).toBeInTheDocument();
+    expect(screen.getByText('Next module locked')).toBeInTheDocument();
   });
 
   it('returns undefined for missing module', () => {
@@ -39,5 +41,22 @@ describe('ModulePage', () => {
       />
     );
     expect(screen.getByRole('heading', { name: 'Action Potentials' })).toBeInTheDocument();
+  });
+
+  it('unlocks next module after marking complete', async () => {
+    const mod = getMdxModule('neuro101', 'neuro101-01');
+    render(
+      <ModulePagePure
+        courseId='neuro101'
+        moduleId='neuro101-01'
+        Content={mod!.Component}
+      />
+    );
+    const button = screen.getByRole('button', { name: /mark complete/i });
+    await userEvent.click(button);
+    expect(screen.getByRole('link', { name: /next module/i })).toHaveAttribute(
+      'href',
+      '/courses/neuro101/modules/neuro101-02'
+    );
   });
 });


### PR DESCRIPTION
Closes frontend/TODO#M3-2

## Implementation details
- added module metadata registry and helper
- introduced `MarkCompleteSection` client component to handle completion logic
- updated `ModulePage` to use new component and compute next module
- configured Jest moduleNameMapper and added user-event for tests

All tests and build pass.


------
https://chatgpt.com/codex/tasks/task_e_684b06c1bdd483338a4ad154c13f1057